### PR TITLE
Añadida pantalla de informe para visualizar la cantidad de audios por tag.

### DIFF
--- a/pialara/blueprints/audios.py
+++ b/pialara/blueprints/audios.py
@@ -2,6 +2,7 @@ import os.path
 import boto3
 import random
 
+from bson.objectid import ObjectId
 import bson.objectid
 from flask import current_app
 from flask import Blueprint, render_template
@@ -16,6 +17,8 @@ from pialara.models.Frases import Frases
 from pialara.models.Usuario import Usuario
 from pialara.models.Syllabus import Syllabus
 from pialara.models.Clicks import Clicks
+
+from pialara.decorators import rol_required
 
 from datetime import datetime
 from random import sample
@@ -231,3 +234,69 @@ def tag_search():
         flash("No se han encontrado resultados de la etiqueta '" + tag_name + "'", "danger")
 
     return render_template('audios/client_tag.html', tags=tags, tag_name=tag_name)
+
+@bp.route('/client-report', methods=['GET'])
+@bp.route('/client-report/<id>', methods=['GET'])
+@rol_required(['admin', 'tecnico', 'cliente'])
+@login_required
+def client_report(id=None):
+    total_audios = 0
+    audios_por_categoria = {}
+    logged_rol = current_user.rol
+    url = 'audios/client_report.html'
+
+    if id or logged_rol == "cliente":
+        audios_model = Audios()
+        user_id = ObjectId(id) if id else current_user.id
+        pipeline = [
+            {"$match": {"usuario.id": user_id}},
+            {"$group": {"_id": "$texto.tag", "cantidad": {"$sum": 1}}}
+        ]
+        resultado = list(audios_model.aggregate(pipeline))
+
+        if resultado:
+            audios_por_categoria = {doc['_id']: doc['cantidad'] for doc in resultado}
+            total_audios = sum(audios_por_categoria.values())
+            
+    elif logged_rol == "admin":
+        audios_model = Audios()
+        pipeline = [{"$group": {"_id": "$texto.tag", "cantidad": {"$sum": 1}}}]
+        resultado = audios_model.aggregate(pipeline)
+        audios_por_categoria = {doc['_id']: doc['cantidad'] for doc in resultado}
+        total_audios = sum(audios_por_categoria.values())
+        
+    elif logged_rol == "tecnico":
+        usuario_model = Usuario()
+        pipeline = [
+            {
+                "$match": {
+                "parent": "tecnico@tecnico.com"
+                }
+            },
+            {
+                "$lookup": {
+                    "from": "audios",
+                    "localField": "_id",
+                    "foreignField": "usuario.id",
+                    "as": "audios"
+                }
+            },
+            {
+                "$unwind": "$audios"
+            },
+            {
+                "$group": {
+                    "_id": "$audios.texto.tag",
+                    "cantidad": {
+                        "$sum": 1
+                    }
+                }
+            }
+        ]
+        resultado = usuario_model.aggregate(pipeline)
+        audios_por_categoria = {doc['_id']: doc['cantidad'] for doc in resultado}
+        total_audios = sum(audios_por_categoria.values())
+        
+    audios_por_categoria = dict(sorted(audios_por_categoria.items(), key=lambda x: x[1], reverse=True))
+
+    return render_template(url, total_audios=total_audios, audios_por_categoria=audios_por_categoria, usuario_id=id)

--- a/pialara/templates/audios/client_report.html
+++ b/pialara/templates/audios/client_report.html
@@ -1,0 +1,36 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+<header class="header text-center my-4">
+    {% if usuario_id %}
+        <h1>Resumen de Audios del Usuario</h1>
+    {% else %}
+        <h1>Resumen General de Audios</h1>
+    {% endif %}
+</header>
+
+<section class="container">
+    <!-- Total de audios -->
+    <div class="card mb-4">
+        <div class="card-body text-center">
+            <h2>Total de Audios Grabados</h2>
+            <p class="fs-3">{{ total_audios }}</p>
+        </div>
+    </div>
+
+    <!-- Audios por categoría -->
+    <div class="card">
+        <div class="card-body">
+            <h2 class="text-center">Audios por Categoría</h2>
+            <ul class="list-group">
+                {% for category, count in audios_por_categoria.items() %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    {{ category }}
+                    <span class="badge bg-primary rounded-pill">{{ count }}</span>
+                </li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/pialara/templates/layout.html
+++ b/pialara/templates/layout.html
@@ -58,10 +58,12 @@
             {% if current_user.rol != "cliente" %}
             <li><a href="{{ url_for('users.index') }}" class="d-block text-light p-3 border-0"><i class="bi bi-person-circle lead m-2"></i>Usuarios</a></li>
             <li><a href="{{ url_for('syllabus.index') }}" class="d-block text-light p-3 border-0"><i class="bi bi-book m-2 lead"></i>Frases</a></li>
+            <li><a href="{{ url_for('audios.client_report') }}" class="d-block text-light p-3 border-0"><i class="bi bi-book m-2 lead"></i>Informes</a></li>
             {% endif %}
             {% if current_user.rol == "cliente" %}
             <li><a href="{{ url_for('audios.client_tag') }}" class="d-block text-light p-3 border-0 fs-5"><i class="bi bi-book m-2 lead"></i>Ver etiquetas</a></li>
             <li><a href="{{ url_for('audios.client_text') }}" class="d-block text-light p-3 border-0 fs-5"><i class="bi bi-file-earmark-music m-2 lead"></i>Grabar mi audio</a></li>
+            <li><a href="{{ url_for('audios.client_report') }}" class="d-block text-light p-3 border-0 fs-5"><i class="bi bi-book m-2 lead"></i>Informes</a></li>
             {% endif %}
           </ul>
           <div class="pb-3 text-white text-decoration-none pt-5 text-center">
@@ -94,6 +96,7 @@
             {% if current_user.rol != "cliente" %}
             <li><a href="{{ url_for('users.index') }}" class="d-block text-light p-3 border-0"><i class="bi bi-person-circle lead m-2"></i>Usuarios</a></li>
             <li><a href="{{ url_for('syllabus.index') }}" class="d-block text-light p-3 border-0"><i class="bi bi-book m-2 lead"></i>Frases</a></li>
+            <li><a href="{{ url_for('audios.client_report') }}" class="d-block text-light p-3 border-0"><i class="bi bi-book m-2 lead"></i>Informes</a></li>
             {% endif %}
             {% if current_user.rol == "cliente" %}
             <li>
@@ -107,7 +110,8 @@
                 <li><a href="{{ url_for('audios.client_text') }}" class="d-block text-light border-0 d-flex align-items-center gap-1 fs-5">
                   <i class="bi bi-file-earmark-music m-2 lead"></i>
                   Grabar mi audio
-                </a></li>
+                </a><br /></li>
+                <li><a href="{{ url_for('audios.client_report') }}" class="d-block text-light border-0 d-flex align-items-center gap-1 fs-5"><i class="bi bi-info-circle m-2 lead"></i>Informes</a></li>
               </ul>
             </li>
             {% endif %}

--- a/pialara/templates/users/index.html
+++ b/pialara/templates/users/index.html
@@ -72,9 +72,16 @@
           <p class = "card-text mb-3 tipo_{{ user.rol }}" >
               <i class="bi bi-person"></i>  {{ user.rol }}
           </p>
-          <a href="{{ url_for('users.update',id=user._id) }}" class="btn btn-primary align-self-start mt-auto">
-            <i class="bi bi-pencil me-2"></i>Editar
-          </a>
+          <div class="d-flex gap-2 mt-auto">
+            <a href="{{ url_for('users.update',id=user._id) }}" class="btn btn-primary align-self-start mt-auto">
+              <i class="bi bi-pencil me-2"></i>Editar
+            </a>
+            {% if user.rol == "cliente" %}
+            <a href="{{ url_for('audios.client_report', id=user._id) }}" class="btn btn-secondary align-self-start mt-auto">
+            <i class="bi bi-file-text me-2"></i>Informe
+            </a>
+            {% endif %}
+          </div>
         </section>
       </article>
     {% endfor %}


### PR DESCRIPTION
Añadida pantalla de informe donde visualizar los audios totales y por tag del usuario. Añadido también botón en la tarjeta de los usuarios de tipo cliente para acceder a su informe siendo admin o tecnico. Los usuarios de tipo cliente pueden ver el informe de sus propios audios, los de tipo tecnico pueden visualizar los de sus clientes y los de tipo admin pueden visualizar los de toda la aplicación.